### PR TITLE
Allow overriding requirements on type metapackage

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,7 @@ jobs:
           path: ~/drupal
           allow_plugins: |
             drupal/core-composer-scaffold
+            drupal/core-project-message
             mglaman/composer-drupal-lenient
       - name: Require self
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,7 @@ jobs:
           version: "${{ matrix.drupal }}"
           path: ~/drupal
           allow_plugins: |
+            drupal/core-composer-scaffold
             mglaman/composer-drupal-lenient
       - name: Require self
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
           tools: composer:v2
           extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
       - name: Setup Drupal
-        uses: bluehorndigital/setup-drupal@v1.0.3
+        uses: bluehorndigital/setup-drupal@v1.0.4
         with:
           version: "${{ matrix.drupal }}"
           path: ~/drupal
@@ -56,7 +56,7 @@ jobs:
           tools: composer:v2
           extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
       - name: Setup Drupal
-        uses: bluehorndigital/setup-drupal@v1.0.3
+        uses: bluehorndigital/setup-drupal@v1.0.4
         with:
           version: ^10.0@alpha
           path: ~/drupal
@@ -87,7 +87,7 @@ jobs:
           tools: composer:v2
           extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
       - name: Setup Drupal
-        uses: bluehorndigital/setup-drupal@v1.0.3
+        uses: bluehorndigital/setup-drupal@v1.0.4
         with:
           version: ^9
           path: ~/drupal

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           version: "${{ matrix.drupal }}"
           path: ~/drupal
+          allow_plugins: |
+            mglaman/composer-drupal-lenient
       - name: Require self
         run: |
           cd ~/drupal
@@ -60,6 +62,8 @@ jobs:
         with:
           version: ^10.0@alpha
           path: ~/drupal
+          allow_plugins: |
+            mglaman/composer-drupal-lenient
       - name: Require self
         run: |
           cd ~/drupal
@@ -91,6 +95,8 @@ jobs:
         with:
           version: ^9
           path: ~/drupal
+          allow_plugins: |
+            mglaman/composer-drupal-lenient
       - name: Require self
         run: |
           cd ~/drupal

--- a/src/PackageRequiresAdjuster.php
+++ b/src/PackageRequiresAdjuster.php
@@ -27,9 +27,10 @@ final class PackageRequiresAdjuster
 
     public function applies(PackageInterface $package): bool
     {
+        $type = $package->getType();
         if (
-            $package->getType() === 'drupal-core'
-            || !str_starts_with($package->getType(), 'drupal-')
+            $type === 'drupal-core'
+            || (!str_starts_with($type, 'drupal-') && $type !== 'metapackage')
         ) {
             return false;
         }

--- a/tests/PackageRequiresAdjusterTest.php
+++ b/tests/PackageRequiresAdjusterTest.php
@@ -64,8 +64,10 @@ class PackageRequiresAdjusterTest extends TestCase
             ['foo', 'drupal-console', true],
             ['foo', 'drupal-console-language', true],
             ['foo', 'drupal-config', true],
+            ['foo', 'metapackage', true],
             ['bar', 'drupal-module', false],
             ['baz', 'drupal-theme', false],
+            ['baz', 'metapackage', false]
         ];
     }
 


### PR DESCRIPTION
It is possible to add dependencies on internal subsections/modules of a module these then get a composer type of metapackage but also get the drupal core dependencies added.
Example: drupal/calendar (https://www.drupal.org/project/calendar) has a dependency on drupal/calendar_datetime

Could be added to readme but restriction probably unnecessary.