### PR TITLE
Update to working example with Simplenews, prepare for Drupal 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mglaman/composer-drupal-lenient
+# Drupal Lenient Composer Plugin
 
-Lenient with it, Drupal 10 with it.
+Lenient with it, Drupal 11 with it.
 
 ## Why?
 
@@ -9,7 +9,9 @@ was done to remove a barrier with getting extensions installed via Composer to w
 
 We hit the same problem, again. At DrupalCon Portland we sat down and decided a Composer plugin is the best approach.
 
-See [Add a composer plugin that supports 'composer require-lenient' to support major version transitions](https://www.drupal.org/project/drupal/issues/3267143)
+See [Add a composer plugin that supports 'composer require-lenient' to support major version transitions](https://www.drupal.org/project/drupal/issues/3267143).
+
+Drupal documentation page: [Using Drupal's Lenient Composer Endpoint](https://www.drupal.org/docs/develop/using-composer/using-drupals-lenient-composer-endpoint).
 
 ## How
 
@@ -19,30 +21,35 @@ excluding `drupal-core`. The constraint is set to `'^8 || ^9 || ^10 || ^11'` for
 
 ## Try it
 
-Setup a fresh Drupal 10 site with this plugin (remember to press `y` for the new `allow-plugins` prompt.)
+Set up a fresh Drupal 11 site with this plugin (remember to press `y` for the new `allow-plugins` prompt.)
 
 ```shell
-composer create-project drupal/recommended-project:^10@alpha d10
-cd d10
-composer config minimum-stability dev
+composer create-project drupal/recommended-project d11
+cd d11
 composer require mglaman/composer-drupal-lenient
 ```
 
 The plugin only works against specified packages. To allow a package to have a lenient Drupal core version constraint,
-you must add it to `extra.drupal-lenient.allowed-list`. The following is an example to add Token via the command line 
+you must add it to `extra.drupal-lenient.allowed-list`. The following is an example to add Simplenews via the command line 
 with `composer config`
 
 ```shell
-composer config --merge --json extra.drupal-lenient.allowed-list '["drupal/token"]'
+composer config --merge --json extra.drupal-lenient.allowed-list '["drupal/simplenews"]'
 ```
 
-Now, add a module that does not have a D10 compatible release!
+Now, add a module that does not have a Drupal 11 compatible release!
 
 ```shell
-composer require drupal/token:1.10.0
+composer require drupal/simplenews
 ```
 
-🥳 Now you can use [cweagans/composer-patches](https://github.com/cweagans/composer-patches) to patch the module for Drupal 10 compatibility!
+🥳 Now you can use [cweagans/composer-patches](https://github.com/cweagans/composer-patches) to patch the module for Drupal 11 compatibility!
+
+For a quick start, allow installation by adding the latest version in the module `*.info.yml` file:
+
+```shell
+core_version_requirement: ^9.3 || ^10 || ^11
+```
 
 ## Support when `composer.lock` removed
 

--- a/src/PackageRequiresAdjuster.php
+++ b/src/PackageRequiresAdjuster.php
@@ -22,7 +22,7 @@ final class PackageRequiresAdjuster
         private readonly Composer $composer
     ) {
         $this->drupalCoreConstraint = (new VersionParser())
-            ->parseConstraints('^8 || ^9 || ^10 || ^11');
+            ->parseConstraints('^8 || ^9 || ^10 || ^11 || ^12');
     }
 
     public function applies(PackageInterface $package): bool

--- a/tests/PackageRequiresAdjusterTest.php
+++ b/tests/PackageRequiresAdjusterTest.php
@@ -87,8 +87,9 @@ class PackageRequiresAdjusterTest extends TestCase
             new Constraint('>=', '8.0'),
             new Constraint('>=', '9.0'),
             new Constraint('>=', '10.0'),
+            new Constraint('>=', '11.0'),
         ]);
-        $originalTokenConstraint = new Constraint('>=', '1.10.0');
+        $originalSimplenewsConstraint = new Constraint('>=', '4.0.0');
         $package = new CompletePackage('foo', '1.0', '1.0');
         $package->setType('drupal-module');
         $package->setRequires([
@@ -99,12 +100,12 @@ class PackageRequiresAdjusterTest extends TestCase
                 Link::TYPE_REQUIRE,
                 $originalDrupalCoreConstraint->getPrettyString()
             ),
-            'drupal/token' => new Link(
+            'drupal/simplenews' => new Link(
                 'bar',
-                'drupal/token',
-                $originalTokenConstraint,
+                'drupal/simplenews',
+                $originalSimplenewsConstraint,
                 Link::TYPE_REQUIRE,
-                $originalTokenConstraint->getPrettyString()
+                $originalSimplenewsConstraint->getPrettyString()
             )
         ]);
         $adjuster->adjust($package);
@@ -113,8 +114,8 @@ class PackageRequiresAdjusterTest extends TestCase
             $package->getRequires()['drupal/core']->getConstraint()->getPrettyString()
         );
         self::assertSame(
-            $originalTokenConstraint,
-            $package->getRequires()['drupal/token']->getConstraint()
+            $originalSimplenewsConstraint,
+            $package->getRequires()['drupal/simplenews']->getConstraint()
         );
         if ($coreVersion !== null) {
             self::assertTrue(
@@ -129,8 +130,8 @@ class PackageRequiresAdjusterTest extends TestCase
     public function provideAdjustData(): array
     {
         return [
-            [null, '^8 || ^9 || ^10 || ^11'],
-            ['10.0.0-alpha5', '^8 || ^9 || ^10 || ^11'],
+            [null, '^8 || ^9 || ^10 || ^11 || ^12'],
+            ['10.0.0-alpha5', '^8 || ^9 || ^10 || ^11 || ^12'],
         ];
     }
 }


### PR DESCRIPTION
Drupal 11 has been the official release for a while now (Aug. 2024), and [Token](https://www.drupal.org/project/token) is Drupal 11 ready, but [Simplenews](https://www.drupal.org/project/simplenews) is [not ready](https://dev.acquia.com/drupal11/deprecation_status/projects?names=simplenews) (Acquia D11 readiness).

So maybe we can use Simplenews as an example of a module, which this plugin can unblock in Composer?

Also, perhaps the title could be updated to match the version used on drupal.org, which is "Lenient Composer Plugin"?

I removed the `composer config minimum-stability dev` command, since it does not seem to be necessary, and in my opinion, documentation should use the minimum required steps.

[Drupal 12](https://www.drupal.org/project/drupal/releases/12.0.0) has not been released yet, but perhaps the plugin can be prepared in advance, still? When the first D12 dev version has been released, the README can be updated to `drupal/recommended-project:^12@alpha` to [install the latest release of Drupal](https://www.drupal.org/docs/develop/using-composer/starting-a-site-using-drupal-composer-project-templates#s-install-latest-release-of-drupal-11).