### PR TITLE
Update README for Drupal 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Drupal Lenient Composer Plugin
 
-Lenient with it, Drupal 11 with it.
+Lenient with it, Drupal 12 with it.
 
 ## Why?
 
-The Drupal community introduced a lenient Composer facade that modified the `drupal/core` constraint for packages. This
-was done to remove a barrier with getting extensions installed via Composer to work on making modules Drupal 9 ready.
+When a new version of Drupal is released, contrib modules and themes need to
+be updated as well.
 
-We hit the same problem, again. At DrupalCon Portland we sat down and decided a Composer plugin is the best approach.
+But the version constraint in these extensions can block getting them ready for the next Drupal release, since they cannot be downloaded via Composer.
+
+We hit the same problem, again and again. So at DrupalCon Portland 2024 the Drupal community decided a Composer plugin is the best approach, and introduced a lenient Composer facade that modified the `drupal/core` constraint for packages.
 
 See [Add a composer plugin that supports 'composer require-lenient' to support major version transitions](https://www.drupal.org/project/drupal/issues/3267143).
 
@@ -21,11 +23,11 @@ excluding `drupal-core`. The constraint is set to `'^8 || ^9 || ^10 || ^11 || ^1
 
 ## Try it
 
-Set up a fresh Drupal 11 site with this plugin (remember to press `y` for the new `allow-plugins` prompt.)
+Set up a fresh Drupal 12 site with this plugin (remember to press `y` for the new `allow-plugins` prompt.)
 
 ```shell
-composer create-project drupal/recommended-project d11
-cd d11
+git clone https://git.drupalcode.org/project/drupal drupal12
+cd drupal12
 composer require mglaman/composer-drupal-lenient
 ```
 
@@ -34,25 +36,25 @@ you must add it to `extra.drupal-lenient.allowed-list`. The following is an exam
 with `composer config`
 
 ```shell
-composer config --merge --json extra.drupal-lenient.allowed-list '["drupal/simplenews"]'
+composer config --merge --json extra.drupal-lenient.allowed-list '["drupal/admin_toolbar"]'
 ```
 
-Now, add a module that does [not have a Drupal 11 compatible](https://dev.acquia.com/drupal11/deprecation_status/projects?next_step=Fix%20deprecation%20errors%20found) release!
+Now, add a module that does [not have a Drupal 12 compatible](https://docs.acquia.com/resources/drupal-deprecation-status/12/projects) release!
 
 ```shell
-composer require drupal/simplenews
+composer require drupal/admin_toolbar
 ```
 
-🥳 Now you can use [cweagans/composer-patches](https://github.com/cweagans/composer-patches) to patch the module for Drupal 11 compatibility!
+🥳 Now you can use [cweagans/composer-patches](https://github.com/cweagans/composer-patches) to patch the module for Drupal 12 compatibility!
 
 For a quick start, allow installing the module by installing [Backward Compatibility](https://www.drupal.org/project/backward_compatibility):
 
 > Backward Compatibility allows you to install old Drupal modules in current Drupal.
 
-Alternatively, manually add the latest version in the module `*.info.yml` file:
+Alternatively, manually add support for future versions in the module `*.info.yml` file:
 
 ```shell
-core_version_requirement: ^9.3 || ^10 || ^11
+core_version_requirement: '>=9'
 ```
 
 ## Allowing all packages

--- a/tests/PackageRequiresAdjusterTest.php
+++ b/tests/PackageRequiresAdjusterTest.php
@@ -117,7 +117,7 @@ class PackageRequiresAdjusterTest extends TestCase
             new Constraint('>=', '10.0'),
             new Constraint('>=', '11.0'),
         ]);
-        $originalSimplenewsConstraint = new Constraint('>=', '4.0.0');
+        $originalAdminToolbarConstraint = new Constraint('>=', '3.6.0');
         $package = new CompletePackage('foo', '1.0', '1.0');
         $package->setType('drupal-module');
         $package->setRequires([
@@ -128,12 +128,12 @@ class PackageRequiresAdjusterTest extends TestCase
                 Link::TYPE_REQUIRE,
                 $originalDrupalCoreConstraint->getPrettyString()
             ),
-            'drupal/simplenews' => new Link(
+            'drupal/admin_toolbar' => new Link(
                 'bar',
-                'drupal/simplenews',
-                $originalSimplenewsConstraint,
+                'drupal/admin_toolbar',
+                $originalAdminToolbarConstraint,
                 Link::TYPE_REQUIRE,
-                $originalSimplenewsConstraint->getPrettyString()
+                $originalAdminToolbarConstraint->getPrettyString()
             )
         ]);
         $adjuster->adjust($package);
@@ -142,8 +142,8 @@ class PackageRequiresAdjusterTest extends TestCase
             $package->getRequires()['drupal/core']->getConstraint()->getPrettyString()
         );
         self::assertSame(
-            $originalSimplenewsConstraint,
-            $package->getRequires()['drupal/simplenews']->getConstraint()
+            $originalAdminToolbarConstraint,
+            $package->getRequires()['drupal/admin_toolbar']->getConstraint()
         );
         if ($coreVersion !== null) {
             self::assertTrue(


### PR DESCRIPTION
The README mentions Drupal 11, but that's the current release, so we could update it to mention Drupal 12?

It has been a while since I needed the plugin, and vaguely remembered why it's needed, but not the exact use case ... so perhaps the intro text can be updated, to be more descriptive?

Installing Simplenews in a Drupal 12 installation breaks it, but Admin Toolbar works well, so we could switch to that instead? 

I also updated the version constraint relaxation example ("Alternatively, manually add support for future versions in the module `*.info.yml` file") to include all future versions.

What do you think about these ideas?