### PR TITLE
Use realpath to ensure correct root dir is detected

### DIFF
--- a/src/Drupal/LenientHooks.php
+++ b/src/Drupal/LenientHooks.php
@@ -132,7 +132,7 @@ class LenientHooks
     {
         $installPath = InstalledVersions::getInstallPath('mglaman/composer-drupal-lenient');
         if ($installPath !== null) {
-            return dirname($installPath, 3);
+            return dirname(realpath($installPath), 3);
         }
 
         return null;


### PR DESCRIPTION
LenientHooks can incorrectly detect path in some cases
Specifically, on a lando instance `InstalledVersions::getInstallPath('mglaman/composer-drupal-lenient');` returned `app/vendor/composer/../mglaman/composer-drupal-lenient`. dirname does not correctly handle paths with `../` in them.